### PR TITLE
49 Cent Sale Sign → 49 / 99 Cent Sign

### DIFF
--- a/EN/Moveables_EN.txt
+++ b/EN/Moveables_EN.txt
@@ -1,7 +1,7 @@
 Moveables_EN = {
     50s_Barstool = "50s Bar Stool",
     50s_Seat = "50s Seat",
-    99_Cent_Sale_Sign = "49 Cent Sale Sign",
+    99_Cent_Sale_Sign = "49 / 99 Cent Sign",
     Acacia_Tiles = "Acacia Tiles",
     Administrative_Flag = "Administrative Flag",
     Adult_Education_Sign = "Adult Education Sign",


### PR DESCRIPTION
Changed *49 Cent Sale Sign* to *49 / 99 Cent Sign* – it turns out it is two-sided and each side features different name:
* 49¢ Sale
* 99¢ Special
¢ name may not be supported so I opted to explicitly writing "Cent" and omitting *Sale*/*Special* part, using `/` as delimited. I was thinking about "Sale Sign", but there's already such item in-game.