### PR TITLE
[EN] Add missing sounds

### DIFF
--- a/EN UK/GameSound_EN.txt
+++ b/EN UK/GameSound_EN.txt
@@ -57,6 +57,7 @@ GameSound_EN = {
     GameSound_FirearmShotgunSawnoff = "Sawn-off Shot"
     GameSound_BulletInRifle = "Bullet in Rifle",
     GameSound_BulletOutVarmint = "Bullet Out",
+    GameSound_StormyRifleCock = "Cock a Rifle",
     GameSound_StormyRevolverInsertRound = "Insert Revolver Round",
     GameSound_ShotgunPumpAction = "Shotgun Pump",
     GameSound_StormyShotgunClick = "Shotgun Click",
@@ -90,11 +91,11 @@ GameSound_EN = {
     GameSound_AmbientMusic_VoiceAmbient = "Ambient: Voice",
     GameSound_AmbientMusic_ZombieAmbient = "Ambient: Zombie",
 
-    GameSound_NewMusic_32 = "NewMusic_32",
-    GameSound_NewMusic_33 = "NewMusic_33",
-    GameSound_NewMusic_34 = "NewMusic_34",
-    GameSound_NewMusic_35 = "NewMusic_35",
-    GameSound_NewMusic_36 = "NewMusic_36",
+    GameSound_NewMusic_32 = "Official: 32",
+    GameSound_NewMusic_33 = "Official: 33",
+    GameSound_NewMusic_34 = "Official: 34",
+    GameSound_NewMusic_35 = "Official: 35",
+    GameSound_NewMusic_36 = "Official: 36",
     GameSound_NewMusic_Alone = "Official: Alone",
     GameSound_NewMusic_Ambient = "Official: Ambient",
     GameSound_NewMusic_AmbientGuitar = "Official: Ambient (Guitar)",
@@ -136,6 +137,7 @@ GameSound_EN = {
     GameSound_NewMusic_Surrounded = "Official: Surrounded",
     GameSound_NewMusic_TakeStock = "Official: Take Stock",
     GameSound_NewMusic_TheHorde = "Official: The Horde",
+    GameSound_NewMusic_Death = "Official: Death",
     GameSound_NewMusic_TheInevitable = "Official: The Inevitable",
     GameSound_NewMusic_ThePlan = "Official: The Plan",
     GameSound_NewMusic_TheZombieThreat = "Official: The Zombie Threat",
@@ -293,6 +295,7 @@ GameSound_EN = {
     GameSound_VehicleDoorOpen = "Vehicle Door Open",
     GameSound_LockVehicleDoor = "Vehicle Door Lock",
     GameSound_UnlockVehicleDoor = "Vehicle Door Unlock",
+    GameSound_VehicleDoorIsLocked = "Vehicle Door is Locked",
     GameSound_VehicleDoorsLocked = "Vehicle Door Locked",
     GameSound_VehicleHoodClose = "Vehicle Bonnet Close",
     GameSound_VehicleHoodOpen = "Vehicle Bonnet Open",
@@ -357,7 +360,7 @@ GameSound_EN = {
     
     
 /* Zombie */
-    GameSound_FemaleZombieCombined = "Female ZombieC ombined",
+    GameSound_FemaleZombieCombined = "Female Zombie Combined",
     GameSound_MaleZombieCombined = "Male Zombie Combined",
     GameSound_FemaleZombieAttack = "Female Zombie Attack",
     GameSound_MaleZombieAttack = "Male Zombie Attack",
@@ -386,6 +389,4 @@ GameSound_EN = {
     GameSound_ZombieFootstepsCombined = "Zombie Footsteps Combined",
     GameSound_ZombieSurprisedPlayer = "Zombie Surprised Player",
     GameSound_TutorialZombie = "TutorialZombie",
-
 }
-

--- a/EN/GameSound_EN.txt
+++ b/EN/GameSound_EN.txt
@@ -57,6 +57,7 @@ GameSound_EN = {
     GameSound_FirearmShotgunSawnoff = "Sawed-off Shot"
     GameSound_BulletInRifle = "Bullet in Rifle",
     GameSound_BulletOutVarmint = "Bullet Out",
+    GameSound_StormyRifleCock = "Cock a Rifle",
     GameSound_StormyRevolverInsertRound = "Insert Revolver Round",
     GameSound_ShotgunPumpAction = "Shotgun Pump",
     GameSound_StormyShotgunClick = "Shotgun Click",
@@ -90,11 +91,11 @@ GameSound_EN = {
     GameSound_AmbientMusic_VoiceAmbient = "Ambient: Voice",
     GameSound_AmbientMusic_ZombieAmbient = "Ambient: Zombie",
 
-    GameSound_NewMusic_32 = "NewMusic_32",
-    GameSound_NewMusic_33 = "NewMusic_33",
-    GameSound_NewMusic_34 = "NewMusic_34",
-    GameSound_NewMusic_35 = "NewMusic_35",
-    GameSound_NewMusic_36 = "NewMusic_36",
+    GameSound_NewMusic_32 = "Official: 32",
+    GameSound_NewMusic_33 = "Official: 33",
+    GameSound_NewMusic_34 = "Official: 34",
+    GameSound_NewMusic_35 = "Official: 35",
+    GameSound_NewMusic_36 = "Official: 36",
     GameSound_NewMusic_Alone = "Official: Alone",
     GameSound_NewMusic_Ambient = "Official: Ambient",
     GameSound_NewMusic_AmbientGuitar = "Official: Ambient (Guitar)",
@@ -136,6 +137,7 @@ GameSound_EN = {
     GameSound_NewMusic_Surrounded = "Official: Surrounded",
     GameSound_NewMusic_TakeStock = "Official: Take Stock",
     GameSound_NewMusic_TheHorde = "Official: The Horde",
+    GameSound_NewMusic_Death = "Official: Death",
     GameSound_NewMusic_TheInevitable = "Official: The Inevitable",
     GameSound_NewMusic_ThePlan = "Official: The Plan",
     GameSound_NewMusic_TheZombieThreat = "Official: The Zombie Threat",
@@ -293,6 +295,7 @@ GameSound_EN = {
     GameSound_VehicleDoorOpen = "Vehicle Door Open",
     GameSound_LockVehicleDoor = "Vehicle Door Lock",
     GameSound_UnlockVehicleDoor = "Vehicle Door Unlock",
+    GameSound_VehicleDoorIsLocked = "Vehicle Door is Locked",
     GameSound_VehicleDoorsLocked = "Vehicle Door Locked",
     GameSound_VehicleHoodClose = "Vehicle Hood Close",
     GameSound_VehicleHoodOpen = "Vehicle Hood Open",
@@ -357,7 +360,7 @@ GameSound_EN = {
     
     
 /* Zombie */
-    GameSound_FemaleZombieCombined = "Female ZombieC ombined",
+    GameSound_FemaleZombieCombined = "Female Zombie Combined",
     GameSound_MaleZombieCombined = "Male Zombie Combined",
     GameSound_FemaleZombieAttack = "Female Zombie Attack",
     GameSound_MaleZombieAttack = "Male Zombie Attack",
@@ -386,6 +389,4 @@ GameSound_EN = {
     GameSound_ZombieFootstepsCombined = "Zombie Footsteps Combined",
     GameSound_ZombieSurprisedPlayer = "Zombie Surprised Player",
     GameSound_TutorialZombie = "TutorialZombie",
-
 }
-


### PR DESCRIPTION
Added missing `GameSound_StormyRifleCock`, `GameSound_NewMusic_Death` and `GameSound_FemaleZombieCombined` and changed `GameSound_NewMusic_` to appropriate names as well as fixed one typo and empty line.