### PR TITLE
Update .gitattributes for Traditional Chinese

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@ AF/*.txt text working-tree-encoding=cp1252 encoding=utf-8,
 AR/*.txt text working-tree-encoding=cp1252 encoding=utf-8,
 CA/*.txt text working-tree-encoding=cp1252 encoding=utf-8,
 CH/*.txt text working-tree-encoding=utf-8 encoding=utf-8,
+CH/**/*.txt text working-tree-encoding=utf-8 encoding=utf-8,
 CN/*.txt text working-tree-encoding=utf-8 encoding=utf-8,
 CS/*.txt text working-tree-encoding=cp1250 encoding=utf-8,
 DA/*.txt text working-tree-encoding=cp1252 encoding=utf-8,
@@ -29,6 +30,7 @@ UA/*.txt text working-tree-encoding=cp1251 encoding=utf-8,
 _TVRADIO_TRANSLATIONS/*RU.txt text working-tree-encoding=cp1251 encoding=utf-8,
 _TVRADIO_TRANSLATIONS/*PL.txt text working-tree-encoding=cp1250 encoding=utf-8,
 _TVRADIO_TRANSLATIONS/*CA.txt text working-tree-encoding=cp1252 encoding=utf-8,
+_TVRADIO_TRANSLATIONS/*CH.txt text working-tree-encoding=utf-8 encoding=utf-8,
 
 # exception: keep the language definition/credits utf-8
 */credits.txt text working-tree-encoding=utf-8 encoding=utf-8


### PR DESCRIPTION
Update settings to cover all Traditional Chinese text files.