### PR TITLE
Fix missing `=` for English in 41.78

### DIFF
--- a/EN/UI_EN.txt
+++ b/EN/UI_EN.txt
@@ -513,7 +513,7 @@ UI_EN = {
     UI_optionscreen_AutoDrink = "Automatically drink water when thirsty",
     UI_optionscreen_LeaveKeyInIgnition = "Leave key in ignition",
     UI_optionscreen_AutoWalkContainer = "Auto walk to clicked container"
-    UI_optionscreen_AutoWalkContainer_tt "When enabled, you will automatically move to a clicked container if it is close"
+    UI_optionscreen_AutoWalkContainer_tt = "When enabled, you will automatically move to a clicked container if it is close"
     UI_optionscreen_iso_cursor = "Iso Cursor Visibility",
     UI_optionscreen_ShowCursorWhileAiming = "Show Mouse Cursor While Aiming",
     UI_optionscreen_ShowCursorWhileAiming_tt = "By default, the mouse cursor is hidden when the Iso Cursor is visible.",


### PR DESCRIPTION
Added in 24cc68f8dd201269c36ecdd2e849ff78e8c997cf, probably needs adjustmenet for other language files too.