### PR TITLE
PL: fix credits.txt encoding + add self

### DIFF
--- a/PL/credits.txt
+++ b/PL/credits.txt
@@ -1,9 +1,9 @@
 ------------------------ -
-gÅ‚Ã³wny tÅ‚umacz: -
+g³ówny t³umacz: -
 ------------------------ -
 geras
 ------------------------ -
-w tÅ‚umaczeniu gry pomagajÄ…/pomagali takÅ¼e: -
+w t³umaczeniu gry pomagaj¹/pomagali tak¿e: -
 ------------------------ -
 Insers
 Lord_Venom
@@ -20,7 +20,7 @@ Svarog
 yaczesuaff
 Faalagorn
 ------------------------- -
-zawartoÅ›Ä‡ VHS i CD: -
+zawartoœæ VHS i CD: -
 ------------------------- -
 geras
 An Nickname
@@ -36,7 +36,7 @@ Algi
 Lubek
 yaczesuaff
 ------------------------- -
-zawartoÅ›Ä‡ radia i TV: -
+zawartoœæ radia i TV: -
 ------------------------- -
 geras
 Svarog

--- a/PL/credits.txt
+++ b/PL/credits.txt
@@ -18,6 +18,7 @@ Spazmatic
 welniok
 Svarog
 yaczesuaff
+Faalagorn
 ------------------------- -
 zawartość VHS i CD: -
 ------------------------- -


### PR DESCRIPTION
This fixes the wrong encdoing of credits file displaying like this (as reported on Discord).

https://cdn.discordapp.com/attachments/445923972140367883/1048644532524294314/screenshot_2022-12-03-175656.png

Checked by @geras-PL  to be working fine :)

https://cdn.discordapp.com/attachments/721720729699090475/1049254040388763658/image.png

Also added myself to the list of translators while at it.